### PR TITLE
fix: use int instead of string for collection key

### DIFF
--- a/src/Contract/Entity/TranslatableInterface.php
+++ b/src/Contract/Entity/TranslatableInterface.php
@@ -9,12 +9,12 @@ use Doctrine\Common\Collections\Collection;
 interface TranslatableInterface
 {
     /**
-     * @return Collection<string, TranslationInterface>
+     * @return Collection<int, TranslationInterface>
      */
     public function getTranslations();
 
     /**
-     * @return Collection<string, TranslationInterface>
+     * @return Collection<int, TranslationInterface>
      */
     public function getNewTranslations(): Collection;
 

--- a/src/EventSubscriber/TranslatableEventSubscriber.php
+++ b/src/EventSubscriber/TranslatableEventSubscriber.php
@@ -103,7 +103,6 @@ final class TranslatableEventSubscriber
         $classMetadata->mapOneToMany([
             'fieldName' => 'translations',
             'mappedBy' => 'translatable',
-            'indexBy' => self::LOCALE,
             'cascade' => ['persist', 'remove'],  //FIX ME Merge is not supported for Doctrine/Orm see https://github.com/slevomat/doctrine-orm/blob/master/UPGRADE.md
             'fetch' => $this->translatableFetchMode,
             'targetEntity' => $classMetadata->getReflectionClass()

--- a/src/Model/Translatable/TranslatableMethodsTrait.php
+++ b/src/Model/Translatable/TranslatableMethodsTrait.php
@@ -12,7 +12,7 @@ use Knp\DoctrineBehaviors\Exception\TranslatableException;
 trait TranslatableMethodsTrait
 {
     /**
-     * @return Collection<string, TranslationInterface>
+     * @return Collection<int, TranslationInterface>
      */
     public function getTranslations()
     {
@@ -24,7 +24,7 @@ trait TranslatableMethodsTrait
     }
 
     /**
-     * @param Collection<string, TranslationInterface> $translations
+     * @param Collection<int, TranslationInterface> $translations
      *
      * @phpstan-param iterable<TranslationInterface> $translations
      */
@@ -38,7 +38,7 @@ trait TranslatableMethodsTrait
     }
 
     /**
-     * @return Collection<string, TranslationInterface>
+     * @return Collection<int, TranslationInterface>
      */
     public function getNewTranslations(): Collection
     {
@@ -186,15 +186,18 @@ trait TranslatableMethodsTrait
     protected function findTranslationByLocale(string $locale, bool $withNewTranslations = true): ?TranslationInterface
     {
         $translation = $this->getTranslations()
-            ->get($locale);
+            ->filter(static fn(TranslationInterface $translation) => $translation->getLocale() === $locale)->first();
 
         if ($translation) {
             return $translation;
         }
 
         if ($withNewTranslations) {
-            return $this->getNewTranslations()
-                ->get($locale);
+            $newTranslation = $this->getNewTranslations()
+                ->filter(static fn(TranslationInterface $translation) => $translation->getLocale() === $locale)->first();
+            if ($newTranslation) {
+                return $newTranslation;
+            }
         }
 
         return null;

--- a/src/Model/Translatable/TranslatablePropertiesTrait.php
+++ b/src/Model/Translatable/TranslatablePropertiesTrait.php
@@ -10,14 +10,14 @@ use Knp\DoctrineBehaviors\Contract\Entity\TranslationInterface;
 trait TranslatablePropertiesTrait
 {
     /**
-     * @var Collection<string, TranslationInterface>
+     * @var Collection<int, TranslationInterface>
      */
     protected null|Collection $translations = null;
 
     /**
      * @see mergeNewTranslations
      *
-     * @var null|Collection<string, TranslationInterface>
+     * @var null|Collection<int, TranslationInterface>
      */
     protected null|Collection $newTranslations = null;
 


### PR DESCRIPTION
This is a fake PR, it cherry pick last commit from master and set it on 3.0.7 i.e. before php 8.4
should be remove after